### PR TITLE
🆕 feat: add ItemCol component for DataTable's ItemColContent

### DIFF
--- a/src/Masa.Stack.Components/Locales/en-US.json
+++ b/src/Masa.Stack.Components/Locales/en-US.json
@@ -2,6 +2,8 @@
   "$Text": "English",
   "$DateTimeFormat": "MM/dd/yyyy HH:mm:ss",
   "$DateFormat": "MM/dd/yyyy",
+  "Yes": "Yes",
+  "No": "No",
   "Dashboard": "Dashboard",
   "Favorite": "Favorite",
   "Settings": "Settings",

--- a/src/Masa.Stack.Components/Locales/zh-CN.json
+++ b/src/Masa.Stack.Components/Locales/zh-CN.json
@@ -3,6 +3,8 @@
   "$Text": "中文简体",
   "$DateTimeFormat": "yyyy-MM-dd HH:mm:ss",
   "$DateFormat": "yyyy年MM月dd日",
+  "Yes": "是",
+  "No": "否",
   "Start time cannot be greater than end time": "开始时间不能大于结束时间",
   "End time cannot be less than start time": "结束时间不能小于开始时间",
   "Please select an end time": "请选择结束时间",

--- a/src/Masa.Stack.Components/Masa.Stack.Components.csproj
+++ b/src/Masa.Stack.Components/Masa.Stack.Components.csproj
@@ -14,6 +14,7 @@
 		<PackageReference Include="Masa.Contrib.StackSdks.Mc" Version="0.6.0-preview.3" />
 		<PackageReference Include="Masa.Contrib.Authentication.Identity" Version="0.6.0-preview.3" />
 		<PackageReference Include="Masa.Contrib.StackSdks.Auth" Version="0.6.0-preview.3" />
+		<PackageReference Include="Masa.Utils.Extensions.Enums" Version="0.5.0" />
 		<PackageReference Include="Microsoft.AspNetCore.Authentication.Abstractions" Version="2.2.0" />
 		<PackageReference Include="Microsoft.AspNetCore.SignalR.Client" Version="6.0.6" />
 	</ItemGroup>

--- a/src/Masa.Stack.Components/Shared/IntegrationComponents/ItemCol/ColorHelper.cs
+++ b/src/Masa.Stack.Components/Shared/IntegrationComponents/ItemCol/ColorHelper.cs
@@ -1,0 +1,37 @@
+﻿namespace Masa.Stack.Components;
+
+public static class ColorHelper
+{
+    private readonly static string[] Colors =
+    {
+        "amber",
+        "blue",
+        "blue-grey",
+        "brown",
+        "cyan",
+        "deep-orange",
+        "deep-purple",
+        "green",
+        "grey",
+        "indigo",
+        "light-blue",
+        "light-green",
+        "lime",
+        "orange",
+        "pink",
+        "purple",
+        "red",
+        "teal",
+        "yellow",
+    };
+
+    public static string GetColor(int index)
+    {
+        if (Colors.Length > index)
+        {
+            return Colors[index];
+        }
+
+        return string.Empty;
+    }
+}

--- a/src/Masa.Stack.Components/Shared/IntegrationComponents/ItemCol/SItemCol.razor
+++ b/src/Masa.Stack.Components/Shared/IntegrationComponents/ItemCol/SItemCol.razor
@@ -1,0 +1,48 @@
+﻿@namespace Masa.Stack.Components
+@using static Masa.Stack.Components.JsInitVariables
+@inherits MasaComponentBase
+
+@if (InternalValue is Enum @enum)
+{
+    var desc = @enum.GetDescription().Description;
+
+    if (ChippedEnum && !string.IsNullOrEmpty(desc))
+    {
+        <SColorChip Color="@GetColor(@enum)" Small="SmallChip">@desc</SColorChip>
+    }
+    else
+    {
+        @desc
+    }
+}
+else if (InternalValue is DateTime dateTime)
+{
+    if (dateTime.Kind == DateTimeKind.Utc)
+    {
+        dateTime = dateTime.Add(TimezoneOffset);
+    }
+
+    if (DateTimeValidator!.Invoke(dateTime))
+    {
+        @("")
+    }
+    else
+    {
+        var major = @DateOnly.FromDateTime(dateTime).ToString(DateFormat);
+        string? minor = null;
+        if (!IgnoreTime)
+        {
+            minor = @TimeOnly.FromDateTime(dateTime).ToString(TimeFormat);
+        }
+
+        <PBlockText Primary="@major" Secondary="@minor"></PBlockText>
+    }
+}
+else if (InternalValue is bool b)
+{
+    @BoolFormatter!.Invoke(b)
+}
+else
+{
+    @InternalValue
+}

--- a/src/Masa.Stack.Components/Shared/IntegrationComponents/ItemCol/SItemCol.razor.cs
+++ b/src/Masa.Stack.Components/Shared/IntegrationComponents/ItemCol/SItemCol.razor.cs
@@ -2,23 +2,32 @@
 
 public partial class SItemCol : MasaComponentBase
 {
-    [Parameter] public Func<bool, string>? BoolFormatter { get; set; }
+    [Parameter]
+    public Func<bool, string>? BoolFormatter { get; set; }
 
-    [Parameter] public bool ChippedEnum { get; set; }
+    [Parameter]
+    public bool ChippedEnum { get; set; }
 
-    [Parameter] public bool SmallChip { get; set; }
+    [Parameter]
+    public bool SmallChip { get; set; }
 
-    [Parameter] public Func<Enum, string>? EnumColorFormatter { get; set; }
+    [Parameter]
+    public Func<Enum, string>? EnumColorFormatter { get; set; }
 
-    [Parameter] public Func<DateTime, bool>? DateTimeValidator { get; set; }
+    [Parameter]
+    public Func<DateTime, bool>? DateTimeValidator { get; set; }
 
-    [Parameter] public bool IgnoreTime { get; set; }
+    [Parameter]
+    public bool IgnoreTime { get; set; }
 
-    [Parameter] public string? DateFormat { get; set; }
+    [Parameter]
+    public string? DateFormat { get; set; }
 
-    [Parameter] public string? TimeFormat { get; set; }
+    [Parameter]
+    public string? TimeFormat { get; set; }
 
-    [Parameter, EditorRequired] public object? Value { get; set; }
+    [Parameter, EditorRequired]
+    public object? Value { get; set; }
 
     protected object InternalValue { get; set; } = null!;
 

--- a/src/Masa.Stack.Components/Shared/IntegrationComponents/ItemCol/SItemCol.razor.cs
+++ b/src/Masa.Stack.Components/Shared/IntegrationComponents/ItemCol/SItemCol.razor.cs
@@ -1,0 +1,46 @@
+﻿namespace Masa.Stack.Components;
+
+public partial class SItemCol : MasaComponentBase
+{
+    [Parameter] public Func<bool, string>? BoolFormatter { get; set; }
+
+    [Parameter] public bool ChippedEnum { get; set; }
+
+    [Parameter] public bool SmallChip { get; set; }
+
+    [Parameter] public Func<Enum, string>? EnumColorFormatter { get; set; }
+
+    [Parameter] public Func<DateTime, bool>? DateTimeValidator { get; set; }
+
+    [Parameter] public bool IgnoreTime { get; set; }
+
+    [Parameter] public string? DateFormat { get; set; }
+
+    [Parameter] public string? TimeFormat { get; set; }
+
+    [Parameter, EditorRequired] public object? Value { get; set; }
+
+    protected object InternalValue { get; set; } = null!;
+
+    protected override void OnParametersSet()
+    {
+        base.OnParametersSet();
+
+        ArgumentNullException.ThrowIfNull(Value);
+
+        BoolFormatter ??= b => b ? T("Yes") : T("No");
+        DateTimeValidator ??= dateTime => dateTime == default;
+
+        InternalValue = Value;
+    }
+
+    public string GetColor(Enum @enum)
+    {
+        if (EnumColorFormatter is not null)
+        {
+            return EnumColorFormatter.Invoke(@enum);
+        }
+
+        return ColorHelper.GetColor((int)(object)@enum);
+    }
+}

--- a/src/Masa.Stack.Components/Shared/IntegrationComponents/SDataTable.cs
+++ b/src/Masa.Stack.Components/Shared/IntegrationComponents/SDataTable.cs
@@ -9,6 +9,19 @@ public class SDataTable<TItem> : MDataTable<TItem>
     {
         HideDefaultFooter = true;
         FixedHeader = true;
+
+        ItemColContent = item =>
+        {
+            void Content(RenderTreeBuilder builder)
+            {
+                builder.OpenComponent(0, typeof(SItemCol));
+                builder.AddAttribute(1, nameof(SItemCol.Value), item.Value);
+                builder.CloseComponent();
+            }
+
+            return Content;
+        };
+
         await base.SetParametersAsync(parameters);
     }
 
@@ -18,8 +31,7 @@ public class SDataTable<TItem> : MDataTable<TItem>
         Class ??= "";
         if (Class.Contains("table-border-none") is false)
             Class += " table-border-none";
-        if(Dense && Class.Contains("dense") is false)
+        if (Dense && Class.Contains("dense") is false)
             Class += " dense";
     }
 }
-

--- a/tests/MasaWebApp/Data/WeatherForecast.cs
+++ b/tests/MasaWebApp/Data/WeatherForecast.cs
@@ -1,13 +1,21 @@
-﻿namespace MasaWebApp.Data
+﻿namespace MasaWebApp.Data;
+
+public class WeatherForecast
 {
-    public class WeatherForecast
-    {
-        public DateTime Date { get; set; }
+    public DateTime Date { get; set; }
 
-        public int TemperatureC { get; set; }
+    public int TemperatureC { get; set; }
 
-        public int TemperatureF => 32 + (int)(TemperatureC / 0.5556);
+    public int TemperatureF => 32 + (int)(TemperatureC / 0.5556);
 
-        public string? Summary { get; set; }
-    }
+    public string? Summary { get; set; }
+
+    public Level Level { get; set; }
+}
+
+public enum Level
+{
+    Normal,
+    Low,
+    High
 }

--- a/tests/MasaWebApp/Data/WeatherForecastService.cs
+++ b/tests/MasaWebApp/Data/WeatherForecastService.cs
@@ -13,7 +13,8 @@
             {
                 Date = startDate.AddDays(index),
                 TemperatureC = Random.Shared.Next(-20, 55),
-                Summary = Summaries[Random.Shared.Next(Summaries.Length)]
+                Summary = Summaries[Random.Shared.Next(Summaries.Length)],
+                Level = (Level)Random.Shared.Next(0, 3)
             }).ToArray());
         }
     }

--- a/tests/MasaWebApp/Pages/FetchData.razor
+++ b/tests/MasaWebApp/Pages/FetchData.razor
@@ -10,33 +10,41 @@
 
 @if (forecasts == null)
 {
-    <p><em>Loading...</em></p>
+    <p>
+        <em>Loading...</em>
+    </p>
 }
 else
 {
-    <MDataTable Headers="_headers" Items="forecasts" HideDefaultFooter ItemsPerPage="5" Class="elevation-1">
+    <h5>Default SDataTable</h5>
+    <SDataTable Headers="_headers" Items="forecasts" HideDefaultFooter ItemsPerPage="5" Class="elevation-1">
+        <FooterContent>
+            <SDataTableFooter Class="mb-4 mt-2" Total="100" Page=1 PageSize=20 />
+        </FooterContent>
+    </SDataTable>
+
+    <h5>SDataTable with custom ItemColContent</h5>
+    <SDataTable Headers="_headers" Items="forecasts" HideDefaultFooter ItemsPerPage="5" Class="elevation-1">
         <ItemColContent>
-            @if (context.Header.Value == nameof(WeatherForecast.Date))
-            {
-                @context.Item.Date.ToShortDateString()
-            }
-            else
-            {
-                @context.Value
-            }
-            </ItemColContent>
-            <FooterContent>
-                <SDataTableFooter Class="mb-4 mt-2" Total="100" Page=1 PageSize=20 />
-            </FooterContent>
-    </MDataTable>
+            <SItemCol Value="@context.Value" ChippedEnum
+                      EnumColorFormatter="EnumColorFormatter">
+            </SItemCol>
+        </ItemColContent>
+        <FooterContent>
+            <SDataTableFooter Class="mb-4 mt-2" Total="100" Page=1 PageSize=20 />
+        </FooterContent>
+    </SDataTable>
 }
 
 @code {
-    private List<DataTableHeader<WeatherForecast>> _headers = new List<DataTableHeader<WeatherForecast>> {
-        new (){ Text = "Date",Value = nameof(WeatherForecast.Date) },
-        new (){ Text = "Temp. (C)",Value = nameof(WeatherForecast.TemperatureC) },
-        new (){ Text = "Temp. (F)",Value = nameof(WeatherForecast.TemperatureF) },
-        new (){ Text = "Summary",Value = nameof(WeatherForecast.Summary),Sortable = false}
+
+    private List<DataTableHeader<WeatherForecast>> _headers = new List<DataTableHeader<WeatherForecast>>
+    {
+        new() { Text = "Date", Value = nameof(WeatherForecast.Date) },
+        new() { Text = "Temp. (C)", Value = nameof(WeatherForecast.TemperatureC) },
+        new() { Text = "Temp. (F)", Value = nameof(WeatherForecast.TemperatureF) },
+        new() { Text = "Summary", Value = nameof(WeatherForecast.Summary), Sortable = false },
+        new() { Text = "Level", Value = nameof(WeatherForecast.Level), Sortable = false }
     };
 
     private WeatherForecast[]? forecasts;
@@ -45,4 +53,18 @@ else
     {
         forecasts = await ForecastService.GetForecastAsync(DateTime.Now);
     }
+
+    private string EnumColorFormatter(Enum e)
+    {
+        if (e is not Level level) return string.Empty;
+
+        return level switch
+        {
+            Level.Normal => "grey",
+            Level.Low => "pink",
+            Level.High => "red",
+            _ => string.Empty
+        };
+    }
+
 }


### PR DESCRIPTION
`<SItemCol Value="@context.Value">` 用于格式化传入的Value并展示在页面上。一般用于DataTable的`ItemColContent`插槽。
- 如果是Kind=UTC的DateTime值会自动加上时区。
- 如果是枚举，会自动拿`[Description]`。开启`ChipEnum`会用**MChip**组件包裹，并"随机"给一个颜色，可以使用`EnumColorFormatter`自定义颜色。
- 如果是Bool类型，会以“是”和“否”代替，可以用`BoolFormatter`自定义。

**SDataTable**组件默认将**SItemCol**作为`ItemColContent`的插槽，所以用了**SDataTable**就不用自己去给时间加时区。

例子看 sample 里的 FetchData.razor。