### PR TITLE
Fix: UI SSlect component item style margin value

### DIFF
--- a/src/Masa.Stack.Components/Shared/IntegrationComponents/SSelect.cs
+++ b/src/Masa.Stack.Components/Shared/IntegrationComponents/SSelect.cs
@@ -42,6 +42,7 @@ public class SSelect<TItem, TItemValue, TValue> : MSelect<TItem, TItemValue, TVa
         base.OnParametersSet();
 
         Class ??= "";
+        Class += " s-slect";
         if (Large is false && Small is false) Medium = true;
         if (Dense is true)
         {

--- a/src/Masa.Stack.Components/wwwroot/css/app.css
+++ b/src/Masa.Stack.Components/wwwroot/css/app.css
@@ -495,11 +495,12 @@ body, .masa-stack-components {
 .masa-stack-components .m-text-field--outlined.m-input--dense.m-input--dense-56 .m-label--active {
     transform: translateY(-24.5px) scale(0.75);
 }
-
+.masa-stack-components .s-slect.m-text-field--outlined.m-input--dense .m-chip{
+    margin: 4px;
+}
 /*
     default dataTable
 */
-
 .masa-stack-components .table-border-none thead th {
     border-bottom: 0px !important;
     box-shadow: none !important;

--- a/tests/MasaWebApp/Item.cs
+++ b/tests/MasaWebApp/Item.cs
@@ -1,0 +1,15 @@
+﻿using System;
+using System.Collections.Generic;
+using System.Linq;
+using System.Text;
+using System.Threading.Tasks;
+
+namespace MasaWebApp;
+
+public class Item
+{
+    public int Id { get; set; }
+    public string Name { get; set; }
+    public string Color { get; set; }
+    public string RelateName { get; set; }
+}


### PR DESCRIPTION
# Description

_UI SSlect component item style margin value is 4px override_

## Issue reference

We strive to have all PR being opened based on an issue, where the problem or feature have been discussed prior to implementation.

Please reference the issue this PR will close: #_[issue number]_

## Checklist

Please make sure you've completed the relevant tasks for this PR, out of the following list:

* [ ] Code compiles correctly
* [ ] Created/updated tests
* [ ] Extended the documentation
