### PR TITLE
fix: adjust parameter DefaultQuickRange  to nullable

### DIFF
--- a/src/Masa.Stack.Components/Shared/IntegrationComponents/DateTime/SDateTimeRangeToolbar.razor
+++ b/src/Masa.Stack.Components/Shared/IntegrationComponents/DateTime/SDateTimeRangeToolbar.razor
@@ -64,7 +64,7 @@
 @code
 {
     [Parameter]
-    public QuickRangeKey DefaultQuickRange { get; set; } = QuickRangeKey.Last12Hours;
+    public QuickRangeKey? DefaultQuickRange { get; set; } = QuickRangeKey.Last12Hours;
 
     [Parameter]
     public EventCallback<QuickRangeKey?> DefaultQuickRangeChanged { get; set; }


### PR DESCRIPTION
Applies to "DefaultQuickRangeChanged".
