### PR TITLE
fix: support auto width for DateTimeRangeToolbar and DateTimeRangeQuickPicker

### DIFF
--- a/src/Masa.Stack.Components/Shared/IntegrationComponents/DateTime/SDateTimeRangeQuickPicker.razor
+++ b/src/Masa.Stack.Components/Shared/IntegrationComponents/DateTime/SDateTimeRangeQuickPicker.razor
@@ -5,25 +5,30 @@
        OffsetY NudgeBottom="8" OpenOnClick CloseOnContentClick="false"
        ContentClass="px-6 py-4 white" ContentStyle="border-radius:16px">
     <ActivatorContent>
-        <div class="d-inline-flex align-center">
-            <MButton Text Small Class="d-flex align-center mr-1 pa-0"
-                     Style="font-size: 14px;"
+	@{
+	    var dateTimeButtonStyle = $"font-size: 14px; width: calc(100% - {(ShowTimeZoneSelector ? "66px" : "24px")})";
+	}
+        <div class="d-inline-flex align-center @Class" style="min-width: @MinWidth; @Style">
+            <MButton Text Small Class="mr-1 pa-0"
+                     Style="@dateTimeButtonStyle"
                      @attributes="@context.Attrs">
-                <MIcon Size="20" Class="mr-2">mdi-calendar-month</MIcon>
-                <div class="datetimetext">@FormatDateTime(StartDateTime,T("Start time"))</div>
-                <MDivider Vertical Class="mx-2" Style="align-self: auto; height: 14px;" />
-                <div class="datetimetext">@FormatDateTime(EndDateTime,T("End time"))</div>
+                <MIcon Size="20" Class="mx-2" >mdi-calendar-month</MIcon>
+		<div style="width: calc(100% - 28px)">
+                    <div class="datetimetext">@FormatDateTime(StartDateTime,T("Start time"))</div>
+                    <MDivider Vertical Class="mx-2" Style="align-self: auto; height: 14px;" />
+                    <div class="datetimetext">@FormatDateTime(EndDateTime,T("End time"))</div>
+		</div>
             </MButton>
             @if (Clearable&&(StartDateTime.HasValue||EndDateTime.HasValue))
             {
                 <MButton Icon XSmall OnClick="ClearClick" OnClickPreventDefault Class="mr-1" Color="grey lighten-2">
                     <MIcon>mdi-close-circle</MIcon>
                 </MButton>
-            }
-            @if (ShowTimeZoneSelector)
-            {
-                <STimeZoneDisplay Offset="@_offset" />
-            }
+	    }
+	    @if (ShowTimeZoneSelector)
+	    {
+                <STimeZoneDisplay Offset="@_offset" Class="ml-auto" />
+	    }
         </div>
     </ActivatorContent>
     <ChildContent>

--- a/src/Masa.Stack.Components/Shared/IntegrationComponents/DateTime/SDateTimeRangeQuickPicker.razor.cs
+++ b/src/Masa.Stack.Components/Shared/IntegrationComponents/DateTime/SDateTimeRangeQuickPicker.razor.cs
@@ -38,6 +38,12 @@ public partial class SDateTimeRangeQuickPicker
     [Parameter]
     public bool Clearable { get; set; } = false;
 
+    [Parameter]
+    public string Class { get; set; } = string.Empty;
+
+    [Parameter]
+    public string Style { get; set; } = string.Empty;
+
     [Inject]
     public JsInitVariables JsInitVariables { get; set; } = default!;
 
@@ -69,6 +75,8 @@ public partial class SDateTimeRangeQuickPicker
 
 
     private bool HasTimeZoneChange => _offset != _internalOffset;
+
+    private string MinWidth => ShowTimeZoneSelector ? "447px" : "405px";
 
     protected override async Task OnAfterRenderAsync(bool firstRender)
     {

--- a/src/Masa.Stack.Components/Shared/IntegrationComponents/DateTime/SDateTimeRangeQuickPicker.razor.css
+++ b/src/Masa.Stack.Components/Shared/IntegrationComponents/DateTime/SDateTimeRangeQuickPicker.razor.css
@@ -12,7 +12,7 @@
 }
 
 .datetimetext {
-    width: 156px;
+    width: calc(50% - 20px);
     padding: 0;
     font-family: 'Roboto';
     line-height: 21px;

--- a/src/Masa.Stack.Components/Shared/IntegrationComponents/DateTime/SDateTimeRangeToolbar.razor
+++ b/src/Masa.Stack.Components/Shared/IntegrationComponents/DateTime/SDateTimeRangeToolbar.razor
@@ -1,9 +1,10 @@
 ﻿@namespace Masa.Stack.Components
 @inherits MasaComponentBase
 
-<div class="d-inline-flex align-center rounded-lg px-4 @Class"
-     style="border:1px solid #E4E8F3; height: 40px; background-color:white;">
+<div class="d-inline-flex align-center rounded-lg pl-2 pr-4 @Class"
+     style="border:1px solid #E4E8F3; height: 40px; background-color:white; min-width: min-content">
     <SDateTimeRangeQuickPicker @bind-StartDateTime="_startDateTime"
+			       Style="@_quickPickerStyle"
                                StartTimeLimit="StartTimeLimit"
                                EndTimeLimit="EndTimeLimit"
                                @bind-EndDateTime="_endDateTime"
@@ -15,50 +16,52 @@
     @if (ShowQuickChange)
     {
         <MDivider Vertical Class="mx-2"></MDivider>
-
-        <SDropdown @bind-Value="_selectedQuickRangeKey"
-               Items="QuickRangeItems"
-               ItemText="item => T(scope: DateTimeRangeScope, item.Key.ToString())"
-               ItemValue="item => item.Key"
-               ItemDisabled="item => item.Disabled"
-               TItem="QuickRange"
-               TValue="QuickRangeKey"
-               OnItemClick="OnRelatedTimeSpanSelected">
-            <ActivatorContent>
-                <MButton Small @attributes="@context.Attrs" Text Class="text-capitalize">
-                @T(scope: DateTimeRangeScope, _selectedQuickRangeKey.ToString())
-                <MIcon Right>mdi-menu-down</MIcon>
-            </MButton>
-        </ActivatorContent>
-    </SDropdown>
+	
+	<div style="min-width: 85px;">
+            <SDropdown @bind-Value="_selectedQuickRangeKey"
+                Items="QuickRangeItems"
+		ItemText="item => T(scope: DateTimeRangeScope, item.Key.ToString())"
+		ItemValue="item => item.Key"
+		ItemDisabled="item => item.Disabled"
+		TItem="QuickRange"
+		TValue="QuickRangeKey"
+		OnItemClick="OnRelatedTimeSpanSelected"	>
+		<ActivatorContent>
+		    <MButton Small Text Class="text-capitalize">
+			@T(scope: DateTimeRangeScope, _selectedQuickRangeKey.ToString())
+			<MIcon Right>mdi-menu-down</MIcon>
+		    </MButton>
+		</ActivatorContent>
+	    </SDropdown>
+	</div>
     }
     @if (ShowInterval)
     {
         <MDivider Vertical Class="mx-2" />
 
-        <SDropdown Items="IntervalItem.Items"
-               ItemValue="item => item"
-               ItemText="item => T(scope: DateTimeRangeScope, item.Text)"
-               @bind-Value="Interval"
-               TItem="IntervalItem"
-               TValue="IntervalItem"
-               OnItemClick="OnIntervalSelected">
-            <PrependContent>
-                <MButton Icon Small OnClick="Refresh">
-                <MIcon Small>mdi-refresh</MIcon>
-            </MButton>
-        </PrependContent>
-        <ActivatorContent>
-            @{
+	<div style="width: 115px;">
+            <SDropdown Items="IntervalItem.Items"
+		       ItemValue="item => item"
+		       ItemText="item => T(scope: DateTimeRangeScope, item.Text)"
+		       @bind-Value="Interval"
+		       TItem="IntervalItem"
+		       TValue="IntervalItem"
+		       OnItemClick="OnIntervalSelected">
+		<PrependContent>
+                    <MButton Icon Small OnClick="Refresh">
+			<MIcon Small>mdi-refresh</MIcon>
+		    </MButton>
+		</PrependContent>
+		<ActivatorContent>
                     <MButton Text Small Icon="false"
-                         @attributes="@context.Attrs">
-                    <span class="mr-1">@T(scope: DateTimeRangeScope, Interval.Text)</span>
-                    <MIcon Small Right="@false">mdi-menu-down</MIcon>
-                        </MButton>
-                }
-            </ActivatorContent>
-        </SDropdown>
-    }
+                        @attributes="@context.Attrs">
+                        <span class="mr-1">@T(scope: DateTimeRangeScope, Interval.Text)</span>
+                        <MIcon Small Right="@false">mdi-menu-down</MIcon>
+                    </MButton>                    
+		</ActivatorContent>
+            </SDropdown>
+	</div>
+	}
 </div>
 
 @code
@@ -149,6 +152,7 @@
     private QuickRange _quickRange = QuickRange.DefaultQuickRange;
 
     private List<QuickRange> _quickRangeItems = QuickRange.DefaultQuickRanges;
+    private string _quickPickerStyle = string.Empty;
 
     protected override async Task OnInitializedAsync()
     {
@@ -169,6 +173,8 @@
     {
         if (firstRender)
         {
+	    setQuickPickerStyle();
+	    
             if (UseAbsoluteTime && _startDateTime != DateTimeOffset.MinValue && _endDateTime != DateTimeOffset.MinValue)
             {
                 await OnAbsoluteDateTimeUpdated();
@@ -176,13 +182,30 @@
             else
             {
                 if (ShowQuickChange && (StartDateTime is not null && EndDateTime is not null))
-                    await UpdateRangeDateTimeToLatest();
+                await UpdateRangeDateTimeToLatest();
             }
             if (ShowInterval)
-                HandleIntervalUpdate(Interval);
+            HandleIntervalUpdate(Interval);
             StateHasChanged();
         }
         await base.OnAfterRenderAsync(firstRender);
+    }
+
+    private void setQuickPickerStyle()
+    {
+	_quickPickerStyle = "width: calc(100% - 200px)";
+	if (ShowQuickChange && !ShowInterval)
+	{
+	    _quickPickerStyle = "width: calc(100% - 85x)";
+	}
+	if (!ShowQuickChange && ShowInterval)
+	{
+	    _quickPickerStyle = "width: calc(100% - 115px)";
+	}
+	if (!ShowQuickChange && !ShowInterval)
+	{
+	    _quickPickerStyle = "width: 100%";
+	}
     }
 
     private async Task OnTimeZoneInfoChange(TimeZoneInfo timeZoneInfo)
@@ -201,14 +224,14 @@
             }
         }
         if (OnTimeZoneUpdate.HasDelegate)
-            await OnTimeZoneUpdate.InvokeAsync(timeZoneInfo);
+        await OnTimeZoneUpdate.InvokeAsync(timeZoneInfo);
         StateHasChanged();
     }
 
     private async Task GetOffset()
     {
         if (Math.Floor(JsInitVariables.TimezoneOffset.TotalMinutes) == 0)
-            await JsInitVariables.SetTimezoneOffset();
+        await JsInitVariables.SetTimezoneOffset();
         Offset = JsInitVariables.TimezoneOffset;
     }
 
@@ -239,7 +262,7 @@
 
                 await OnUpdate.InvokeAsync((_startDateTime, _endDateTime));
             }
-        }
+}
     }
 
 

--- a/src/Masa.Stack.Components/Shared/IntegrationComponents/DateTime/STimeZoneDisplay.razor
+++ b/src/Masa.Stack.Components/Shared/IntegrationComponents/DateTime/STimeZoneDisplay.razor
@@ -3,7 +3,7 @@
 
 <MTooltip Top>
     <ActivatorContent>
-        <span class="m-chip m-size--small m-chip--label theme--light secondary" @attributes="@context.Attrs">@(Offset.Hours > 0 ? $"+{Offset.Hours}" : Offset.Hours.ToString())</span>
+        <span class="m-chip m-size--small m-chip--label theme--light secondary @Class" @attributes="@context.Attrs">@(Offset.Hours > 0 ? $"+{Offset.Hours}" : Offset.Hours.ToString())</span>
     </ActivatorContent>
     <ChildContent>
         <span>@(T(scope: DateTimeRangeScope, "Current Selected TimeZone"))</span>
@@ -14,4 +14,7 @@
 
     [Parameter]
     public TimeSpan Offset { get; set; }
+
+    [Parameter]
+    public string Class { get; set; } = string.Empty;
 }

--- a/src/Masa.Stack.Components/Shared/Layouts/Components/Modals/Model/UpdatePasswordModelValidator.cs
+++ b/src/Masa.Stack.Components/Shared/Layouts/Components/Modals/Model/UpdatePasswordModelValidator.cs
@@ -5,8 +5,7 @@ public class UpdatePasswordModelValidator : AbstractValidator<UpdatePasswordMode
     public UpdatePasswordModelValidator(I18n i18N)
     {
         RuleFor(m => m.OldPassword)
-            .Matches(@"^\s{0}$|^\S*(?=\S{6,})(?=\S*\d)(?=\S*[A-Za-z])\S*$")
-            .WithMessage(i18N.T("PasswordFormatVerificationPrompt"))
+	    .NotEmpty()
             .WithName(i18N.T("OldPassword"));
         RuleFor(m => m.NewPassword)
             .NotEmpty()


### PR DESCRIPTION
<img width="2550" alt="image" src="https://user-images.githubusercontent.com/45676208/232741824-3d979c52-31aa-4d8a-b202-8e7db6825090.png">
