### PR TITLE
fix: team permission cancel state display error and top menu state

### DIFF
--- a/src/Masa.Stack.Components/Shared/GlobalNavigations/ExpansionAppItem.razor
+++ b/src/Masa.Stack.Components/Shared/GlobalNavigations/ExpansionAppItem.razor
@@ -43,7 +43,7 @@
                             {
                                 <MIcon Small Class="mr-1" Color="primary">mdi-check</MIcon>
                             }
-                            else if (!Data.HasActions && Data.Reversed)
+                            else if (Reversed)
                             {
                                 <MIcon Small Class="mr-1" Color="red">mdi-close</MIcon>
                             }
@@ -85,7 +85,7 @@
                             {
                                 <MIcon Small Class="mr-1" Color="primary">mdi-check</MIcon>
                             }
-                            else if (Data.Reversed)
+                            else if (Reversed)
                             {
                                 <MIcon Small Class="mr-1" Color="red">mdi-close</MIcon>
                             }

--- a/src/Masa.Stack.Components/Shared/GlobalNavigations/ExpansionAppItem.razor.cs
+++ b/src/Masa.Stack.Components/Shared/GlobalNavigations/ExpansionAppItem.razor.cs
@@ -71,7 +71,35 @@ public partial class ExpansionAppItem
 
     private bool IsDisabled => InPreview || Data.Disabled;
 
-    public bool Indeterminate => !IsQueryNav && (Data.HasActions || Data.HasChildren) && ExpansionApp.ExpansionAppItems.Any(item => item.IsChecked && (Data.Code == item.Data.ParentCode || Data.Code == item.Data.Code)) && ExpansionApp.ExpansionAppItems.Any(item => !item.IsChecked && item.Data.ParentCode == Data.Code);
+    public bool Indeterminate
+    {
+        get
+        {
+            if (Level == 1)
+            {
+                var childrens = ExpansionApp.CategoryAppNavs.IntersectBy(Data.Children, item => item.NavModel!).Select(item => item.Nav);
+                var items = ExpansionApp.ExpansionAppItems.Where(p => childrens.Contains(p.Data.Code) || childrens.Contains(p.Data.ParentCode));
+		return items.Any(item => item.IsChecked) && items.Any(item => !item.IsChecked);
+            }
+
+            return !IsQueryNav && (Data.HasActions || Data.HasChildren) && ExpansionApp.ExpansionAppItems.Any(item => item.IsChecked && (Data.Code == item.Data.ParentCode || Data.Code == item.Data.Code)) && ExpansionApp.ExpansionAppItems.Any(item => !item.IsChecked && item.Data.ParentCode == Data.Code);
+        }
+    }
+
+    public bool Reversed
+    {
+        get
+	{
+            if (Data.HasChildren)
+            {
+                return Data.Children.All(children => children.Reversed);
+            }
+            else
+            {
+                return Data.Reversed;
+            }
+        }
+    }
 
     private string ActiveClass
     {


### PR DESCRIPTION
fix: team permission cancel state display error and top menu state for permission checkbox

![image](https://user-images.githubusercontent.com/45676208/233833291-2569d7d9-91d1-460e-906a-bdd794e37184.png)
