### PR TITLE
style: the selected shadow of the quick selector area is not centred

### DIFF
--- a/global.json
+++ b/global.json
@@ -1,0 +1,7 @@
+{
+  "sdk": {
+    "version": "6.0.0",
+    "rollForward": "latestMajor",
+    "allowPrerelease": false
+  }
+}

--- a/src/Masa.Stack.Components/Shared/IntegrationComponents/DateTime/SDateTimeRangeToolbar.razor
+++ b/src/Masa.Stack.Components/Shared/IntegrationComponents/DateTime/SDateTimeRangeToolbar.razor
@@ -17,8 +17,7 @@
     @if (ShowQuickChange)
     {
         <MDivider Vertical Class="mx-2"></MDivider>
-
-        <div style="min-width: 85px;">
+        <div style="min-width:min-content;margin:0 auto" class="d-flex align-center">
             <SDropdown @bind-Value="_selectedQuickRangeKey"
                        Items="QuickRangeItems"
                        ItemText="item => T(scope: DateTimeRangeScope, item.Key.ToString())"
@@ -28,7 +27,7 @@
                        TValue="QuickRangeKey"
                        OnItemClick="OnRelatedTimeSpanSelected">
                 <ActivatorContent>
-                    <MButton Small Text Class="text-capitalize" @attributes="@context.Attrs">
+                    <MButton Small Text Class="text-capitalize quickchange" @attributes="@context.Attrs">
                         @T(scope: DateTimeRangeScope, _selectedQuickRangeKey.ToString())
                         <MIcon Right>mdi-menu-down</MIcon>
                     </MButton>
@@ -38,7 +37,7 @@
     }
     @if (ShowInterval)
     {
-        <MDivider Vertical Class="mx-2"/>
+        <MDivider Vertical Class="mx-2" />
         <div style="width: 115px;">
             <SDropdown Items="IntervalItem.Items"
                        ItemValue="item => item"

--- a/src/Masa.Stack.Components/Shared/IntegrationComponents/DateTime/SDateTimeRangeToolbar.razor.css
+++ b/src/Masa.Stack.Components/Shared/IntegrationComponents/DateTime/SDateTimeRangeToolbar.razor.css
@@ -1,0 +1,3 @@
+﻿::deep .quickchange {
+    padding: 0 4px !important
+}

--- a/tests/MasaWebApp/Pages/DateTimeRangePickerExample.razor
+++ b/tests/MasaWebApp/Pages/DateTimeRangePickerExample.razor
@@ -10,8 +10,7 @@
                                 Clearable></SDateTimeRangeToolbar>
     </MCol>
     <MCol Cols="6">
-        <SDateTimeRangeToolbar OnUpdate="OnUpdate" OnAutoUpdate="OnUpdate" Class="full-width" MaxPickerWidth="580"
-                               ShowTimeZoneSelector Clearable></SDateTimeRangeToolbar>
+        <SDateTimeRangeToolbar OnUpdate="OnUpdate" OnAutoUpdate="OnUpdate" Class="full-width" ShowTimeZoneSelector ShowInterval ShowQuickChange Clearable></SDateTimeRangeToolbar>
     </MCol>
 </MRow>
 <div class="pa-12 mb-6">


### PR DESCRIPTION
 the selected shadow of the quick selector area is not centred

resolve #601 

add a global.json to use the main release of .net to build

