### PR TITLE
Fix: The top user information and content are not right aligned

### DIFF
--- a/src/Masa.Stack.Components/Shared/Layouts/SLayout.razor
+++ b/src/Masa.Stack.Components/Shared/Layouts/SLayout.razor
@@ -31,8 +31,8 @@
                     <SearchMenu Navs="NavItems"/>  
                 }
                 <MSpacer />
-                <Languages OnChange="() => { }" /> 
-                <MSheet class="d-flex align-center justify-space-between rounded-6 pa-1 mr-n3" Width="100">
+                <Languages OnChange="() => { }" />
+                    <MSheet class="d-flex align-center justify-space-between rounded-6 pa-1 mr-n4" Width="100">
                     <Notification />
                     <User />
                 </MSheet>


### PR DESCRIPTION
# Description

_Fix: The top user information and content are not right aligned_

![图片](https://user-images.githubusercontent.com/714535/236101032-66529df6-3a5b-4024-9162-763a7b52f055.png)

## Issue reference

We strive to have all PR being opened based on an issue, where the problem or feature have been discussed prior to implementation.

Please reference the issue this PR will close: #_[issue number]_

