### PR TITLE
feat(GlobalNavigation): add scroll styling to menu

### DIFF
--- a/src/Masa.Stack.Components/Shared/GlobalNavigations/GlobalNavigation.razor
+++ b/src/Masa.Stack.Components/Shared/GlobalNavigations/GlobalNavigation.razor
@@ -112,7 +112,7 @@
                         }
                         else
                         {
-                            <ExpansionMenuWrapper RenderLayer Value="_menu" OnItemClick="MenuItemClickAsync" OnItemOperClick="MenuItemOperClickAsync" />
+                            <ExpansionMenuWrapper CssForScroll="global-nav-internal" RenderLayer Value="_menu" OnItemClick="MenuItemClickAsync" OnItemOperClick="MenuItemOperClickAsync" />
                         }
                     </div>
                 </div>


### PR DESCRIPTION
Updated the `<ExpansionMenuWrapper>` component in `GlobalNavigation.razor` to include the `CssForScroll` property with the value `global-nav-internal`. This change allows the component to utilize the specified class for scroll styling.
