### PR TITLE
chore: update MasaStackSdksPackageVersion

### DIFF
--- a/Directory.Build.props
+++ b/Directory.Build.props
@@ -4,6 +4,6 @@
 		<MicrosoftPackageVersion Condition="'$(TargetFramework)' == 'net7.0'">7.0.0</MicrosoftPackageVersion>
 		<MicrosoftPackageVersion Condition="'$(TargetFramework)' == 'net8.0'">8.0.0</MicrosoftPackageVersion>
 		<MasaFrameworkPackageVersion>1.2.0-preview.6</MasaFrameworkPackageVersion>
-		<MasaStackSdksPackageVersion>1.2.1-preview.36</MasaStackSdksPackageVersion>
+		<MasaStackSdksPackageVersion>1.2.1-preview.45</MasaStackSdksPackageVersion>
 	</PropertyGroup>
 </Project>


### PR DESCRIPTION
Updated `MasaStackSdksPackageVersion` from `1.2.1-preview.36` to `1.2.1-preview.45` in `Directory.Build.props`.

