### PR TITLE
feat(TeamStateManager): add support for WASM and Server modes

### DIFF
--- a/src/Masa.Stack.Components/Infrastructure/Identity/ITeamStateManager.cs
+++ b/src/Masa.Stack.Components/Infrastructure/Identity/ITeamStateManager.cs
@@ -1,0 +1,26 @@
+namespace Masa.Stack.Components.Infrastructure.Identity;
+
+/// <summary>
+/// 团队状态管理接口，用于兼容 Server 和 WASM 模式
+/// </summary>
+public interface ITeamStateManager
+{
+    /// <summary>
+    /// 设置当前团队ID
+    /// </summary>
+    /// <param name="teamId">团队ID</param>
+    /// <returns></returns>
+    Task SetCurrentTeamAsync(Guid teamId);
+
+    /// <summary>
+    /// 获取当前团队ID
+    /// </summary>
+    /// <returns>团队ID，如果没有设置则返回 Guid.Empty</returns>
+    Task<Guid> GetCurrentTeamAsync();
+
+    /// <summary>
+    /// 清除团队状态
+    /// </summary>
+    /// <returns></returns>
+    Task ClearTeamStateAsync();
+} 

--- a/src/Masa.Stack.Components/Infrastructure/Identity/ServerTeamStateManager.cs
+++ b/src/Masa.Stack.Components/Infrastructure/Identity/ServerTeamStateManager.cs
@@ -1,0 +1,51 @@
+namespace Masa.Stack.Components.Infrastructure.Identity;
+
+/// <summary>
+/// Server 模式的团队状态管理器
+/// 使用 AuthenticationStateManager 来管理团队状态
+/// </summary>
+public class ServerTeamStateManager : ITeamStateManager, IScopedDependency
+{
+    private readonly AuthenticationStateManager _authenticationStateManager;
+    private readonly AuthenticationStateProvider _authenticationStateProvider;
+
+    public ServerTeamStateManager(
+        AuthenticationStateManager authenticationStateManager,
+        AuthenticationStateProvider authenticationStateProvider)
+    {
+        _authenticationStateManager = authenticationStateManager;
+        _authenticationStateProvider = authenticationStateProvider;
+    }
+
+    /// <summary>
+    /// 通过更新身份验证状态中的声明来设置当前团队ID
+    /// </summary>
+    public async Task SetCurrentTeamAsync(Guid teamId)
+    {
+        await _authenticationStateManager.UpsertClaimAsync(IdentityClaimConsts.CURRENT_TEAM, teamId.ToString());
+    }
+
+    /// <summary>
+    /// 从身份验证状态中获取当前团队ID
+    /// </summary>
+    public async Task<Guid> GetCurrentTeamAsync()
+    {
+        var authState = await _authenticationStateProvider.GetAuthenticationStateAsync();
+        var teamIdClaim = authState.User.FindFirst(IdentityClaimConsts.CURRENT_TEAM);
+        
+        if (teamIdClaim != null && Guid.TryParse(teamIdClaim.Value, out var teamId))
+        {
+            return teamId;
+        }
+
+        return Guid.Empty;
+    }
+
+    /// <summary>
+    /// 清除团队状态
+    /// </summary>
+    public async Task ClearTeamStateAsync()
+    {
+        await _authenticationStateManager.UpsertClaimAsync(IdentityClaimConsts.CURRENT_TEAM, Guid.Empty.ToString());
+    }
+} 

--- a/src/Masa.Stack.Components/Infrastructure/Identity/WasmTeamStateManager.cs
+++ b/src/Masa.Stack.Components/Infrastructure/Identity/WasmTeamStateManager.cs
@@ -1,0 +1,76 @@
+namespace Masa.Stack.Components.Infrastructure.Identity;
+
+/// <summary>
+/// WASM 模式的团队状态管理器
+/// 在 WASM 模式下，通过页面刷新获取包含最新团队信息的 token
+/// 经测试发现 RequestAccessToken() 只返回缓存的 token，不会真正刷新，所以使用页面刷新确保可靠性
+/// </summary>
+public class WasmTeamStateManager : ITeamStateManager, IScopedDependency
+{
+    private readonly AuthenticationStateProvider _authenticationStateProvider;
+    private readonly NavigationManager _navigationManager;
+
+    public WasmTeamStateManager(
+        AuthenticationStateProvider authenticationStateProvider,
+        NavigationManager navigationManager)
+    {
+        _authenticationStateProvider = authenticationStateProvider;
+        _navigationManager = navigationManager;
+    }
+
+        /// <summary>
+    /// 在 WASM 模式下设置团队后，获取最新的身份验证状态
+    /// </summary>
+    public async Task SetCurrentTeamAsync(Guid teamId)
+    {
+        try
+        {
+            // 在 WASM 模式下，最可靠的方式是直接刷新页面
+            // 因为 RequestAccessToken() 通常只返回缓存的 token，不会真正刷新
+            // 而团队信息的更新需要服务端重新颁发包含最新 claims 的 token
+            
+            // 短暂延迟确保后端团队信息更新完成
+            await Task.Delay(100);
+            
+            // 直接使用页面刷新，这是最可靠的方式
+            // 页面刷新会重新初始化 OIDC 客户端，获取最新的 token 和 claims
+            _navigationManager.NavigateTo(_navigationManager.Uri, true);
+        }
+        catch (Exception)
+        {
+            // 确保在任何异常情况下都能刷新页面
+            _navigationManager.NavigateTo(_navigationManager.Uri, true);
+        }
+    }
+
+    /// <summary>
+    /// 从当前身份验证状态中获取团队ID
+    /// </summary>
+    public async Task<Guid> GetCurrentTeamAsync()
+    {
+        try
+        {
+            var authState = await _authenticationStateProvider.GetAuthenticationStateAsync();
+            var teamIdClaim = authState.User.FindFirst(IdentityClaimConsts.CURRENT_TEAM);
+
+            if (teamIdClaim != null && Guid.TryParse(teamIdClaim.Value, out var teamId))
+            {
+                return teamId;
+            }
+        }
+        catch (Exception)
+        {
+            // 如果获取失败，返回空的 GUID
+        }
+
+        return Guid.Empty;
+    }
+
+    /// <summary>
+    /// 清除团队状态
+    /// </summary>
+    public async Task ClearTeamStateAsync()
+    {
+        await SetCurrentTeamAsync(Guid.Empty);
+    }
+}

--- a/src/Masa.Stack.Components/Shared/Layouts/Components/User.razor
+++ b/src/Masa.Stack.Components/Shared/Layouts/Components/User.razor
@@ -5,6 +5,7 @@
 @inject IJSRuntime JS
 @inject ILogger<User> Logger
 @inject AuthenticationStateManager AuthenticationStateManager
+@inject ITeamStateManager TeamStateManager
 @inject SignOutSessionStateManager SignOutManager
 
 <MMenu @bind-Value="@MenuVisible" OffsetY NudgeTop="-8" CloseOnContentClick="false"
@@ -148,9 +149,24 @@
             try
             {
                 _teams = await AuthClient.TeamService.GetUserTeamsAsync();
-                if (MasaUser.CurrentTeamId == Guid.Empty && _teams.Any())
+                
+                // 从身份验证状态中获取当前团队信息（在 WASM 模式下来自 token）
+                var currentTeamId = await TeamStateManager.GetCurrentTeamAsync();
+                if (currentTeamId != Guid.Empty && _teams.Any(t => t.Id == currentTeamId))
                 {
+                    // 如果从身份验证状态中找到有效的团队信息，使用它
+                    MasaUser.CurrentTeamId = currentTeamId;
+                    GlobalConfig.CurrentTeamId = currentTeamId;
+                }
+                else if (MasaUser.CurrentTeamId == Guid.Empty && _teams.Any())
+                {
+                    // 如果没有团队信息，则使用第一个团队
                     await CurrentTeamChanged(_teams.First().Id);
+                }
+                else if (MasaUser.CurrentTeamId != Guid.Empty && _teams.Any(t => t.Id == MasaUser.CurrentTeamId))
+                {
+                    // 如果 MasaUser 中有有效的团队信息，使用它
+                    GlobalConfig.CurrentTeamId = MasaUser.CurrentTeamId;
                 }
             }
             catch (Exception e)
@@ -158,8 +174,6 @@
                 Logger.LogError(e, "AuthClient.TeamService.GetUserTeamsAsync");
             }
 
-            MasaUser.CurrentTeamId = CurrentTeam.Id;
-            GlobalConfig.CurrentTeamId = CurrentTeam.Id;            
             StateHasChanged();
         }
         await base.OnAfterRenderAsync(firstRender);
@@ -184,7 +198,8 @@
             await AuthClient.UserService.SetCurrentTeamAsync(teamId);
         }
 
-        await AuthenticationStateManager.UpsertClaimAsync(IdentityClaimConsts.CURRENT_TEAM, teamId.ToString());
+        // 使用新的团队状态管理器，兼容 Server 和 WASM 模式
+        await TeamStateManager.SetCurrentTeamAsync(teamId);
         GlobalConfig.CurrentTeamId = teamId;
         MasaUser.CurrentTeamId = teamId;
         _showChangeTeam = false;


### PR DESCRIPTION
- Implemented ITeamStateManager interface for managing team states.
- Added registration logic for team state manager in ServiceCollectionExtensions.cs.
- Created ServerTeamStateManager and WasmTeamStateManager to handle team state management in respective environments.
- Updated User.razor to utilize the new team state manager for fetching user team information.

