### PR TITLE
调整样式以优化密集输入字段和标题焦点

### DIFF
--- a/src/Masa.Stack.Components/wwwroot/css/app.css
+++ b/src/Masa.Stack.Components/wwwroot/css/app.css
@@ -506,8 +506,6 @@ h1:focus {
 
 .masa-stack-components .m-text-field--outlined.m-input--dense.m-input--dense-48 .m-input__append-inner {
     margin-top: 12px;
-    height: 48px;
-    margin-right: -12px;
 }
 
 .masa-stack-components .m-text-field--outlined.m-input--dense.m-input--dense-40 .m-label {


### PR DESCRIPTION
更新了 `h1:focus` 的 transform 样式以改善视觉效果。
删除了 `.m-input__append-inner` 的部分样式以简化布局。
调整了 `.m-label` 的 top 属性以优化密集模式下的对齐。

