### PR TITLE
调整导航项的内边距以优化布局

### DIFF
--- a/src/Masa.Stack.Components/wwwroot/css/app.css
+++ b/src/Masa.Stack.Components/wwwroot/css/app.css
@@ -181,12 +181,12 @@ h1:focus {
         }
 
         .masa-stack-components .global-nav .nav .action-item {
-            padding: 0 8px 0 24px;
+            padding: 0 8px 0 28px;
             color: #7681AB;
         }
 
         .masa-stack-components .global-nav .nav .action-item2 {
-            padding: 0 8px 0 32px;
+            padding: 0 8px 0 40px;
             color: #7681AB;
         }
 


### PR DESCRIPTION
修改了 `.masa-stack-components .global-nav .nav .action-item` 的 `padding` 属性，将左内边距从 `24px` 调整为 `28px`。 修改了 `.masa-stack-components .global-nav .nav .action-item2` 的 `padding` 属性，将左内边距从 `32px` 调整为 `40px`。