### PR TITLE
refactor(identity): 优化 WASM 模式下的团队状态管理

### DIFF
--- a/src/Masa.Stack.Components/Extensions/ServiceCollectionExtensions.cs
+++ b/src/Masa.Stack.Components/Extensions/ServiceCollectionExtensions.cs
@@ -45,19 +45,15 @@ public static class ServiceCollectionExtensions
         // 注册团队状态管理器 - 根据运行时环境选择合适的实现
         services.AddScoped<ITeamStateManager>(sp =>
         {
-            // 检测是否为 WASM 模式
             if (IsWebAssemblyEnvironment(sp))
             {
-                // WASM 模式：使用 refresh token 获取最新的 token 和 claims
-                var authStateProvider = sp.GetRequiredService<AuthenticationStateProvider>();
                 var navigationManager = sp.GetRequiredService<NavigationManager>();
-                var tokenProvider = sp.GetRequiredService<IAccessTokenProvider>();
+                var jsRuntime = sp.GetRequiredService<IJSRuntime>();
                 var logger = sp.GetRequiredService<ILogger<WasmTeamStateManager>>();
-                return new WasmTeamStateManager(authStateProvider, navigationManager, tokenProvider, logger);
+                return new WasmTeamStateManager(navigationManager, jsRuntime, logger);
             }
             else
             {
-                // Server 模式：直接操作身份验证状态
                 var authStateManager = sp.GetRequiredService<AuthenticationStateManager>();
                 var authStateProvider = sp.GetRequiredService<AuthenticationStateProvider>();
                 return new ServerTeamStateManager(authStateManager, authStateProvider);

--- a/src/Masa.Stack.Components/Infrastructure/Identity/WasmTeamStateManager.cs
+++ b/src/Masa.Stack.Components/Infrastructure/Identity/WasmTeamStateManager.cs
@@ -1,75 +1,36 @@
-using Microsoft.AspNetCore.Components.WebAssembly.Authentication;
-
 namespace Masa.Stack.Components.Infrastructure.Identity;
 
 /// <summary>
 /// WASM 模式的团队状态管理器
-/// 在 WASM 模式下，通过 refresh token 获取包含最新团队信息的 token
+/// 切换团队后清除浏览器中缓存的 OIDC Token，通过页面重载触发静默登录以获取包含最新团队信息的新 Token
 /// </summary>
 public class WasmTeamStateManager : ITeamStateManager, IScopedDependency
 {
-    private readonly AuthenticationStateProvider _authenticationStateProvider;
     private readonly NavigationManager _navigationManager;
-    private readonly IAccessTokenProvider _accessTokenProvider;
+    private readonly IJSRuntime _jsRuntime;
     private readonly ILogger<WasmTeamStateManager> _logger;
 
     public WasmTeamStateManager(
-        AuthenticationStateProvider authenticationStateProvider,
         NavigationManager navigationManager,
-        IAccessTokenProvider accessTokenProvider,
+        IJSRuntime jsRuntime,
         ILogger<WasmTeamStateManager> logger)
     {
-        _authenticationStateProvider = authenticationStateProvider;
         _navigationManager = navigationManager;
-        _accessTokenProvider = accessTokenProvider;
+        _jsRuntime = jsRuntime;
         _logger = logger;
     }
 
-    /// <summary>
-    /// 强制刷新 token，通过清除当前 token 来触发 refresh token 流程
-    /// </summary>
-    private async Task<string?> ForceRefreshTokenAsync()
-    {
-        try
-        {
-            // 通过请求新的 token 来触发 refresh token 流程
-            // 这会在后端更新用户的 claims
-            var refreshTokenResult = await _accessTokenProvider.RequestAccessToken(new AccessTokenRequestOptions
-            {
-                Scopes = new List<string> { "openid", "profile", "offline_access" }
-            });
-
-            if (refreshTokenResult.TryGetToken(out var newToken))
-            {
-                _logger.LogInformation("Token 刷新成功");
-                return newToken.Value;
-            }
-
-            _logger.LogWarning("Token 刷新失败");
-            return null;
-        }
-        catch (Exception ex)
-        {
-            _logger.LogError(ex, "强制刷新 token 时发生错误");
-            return null;
-        }
-    }
-
-    /// <summary>
-    /// 在 WASM 模式下设置团队后，通过 refresh token 获取最新的身份验证状态
-    /// </summary>
     public async Task SetCurrentTeamAsync(Guid teamId)
     {
         try
         {
             _logger.LogInformation("开始切换团队，团队ID: {TeamId}", teamId);
 
-            // 短暂延迟确保后端团队信息更新完成
-            await Task.Delay(100);
+            // 清除浏览器 SessionStorage 中缓存的 OIDC Token，
+            // 使下次认证时必须从 SSO 重新获取包含最新 CURRENT_TEAM claim 的 Token
+            await _jsRuntime.InvokeVoidAsync("MasaStackComponents.clearOidcTokenCache");
 
-            // 强制刷新 token，获取最新的 claims
-            var newToken = await ForceRefreshTokenAsync();
-
+            // 强制刷新页面，框架发现无缓存 Token 后会走 OIDC 静默登录，SSO 颁发新 Token
             _navigationManager.NavigateTo(_navigationManager.Uri, true);
         }
         catch (Exception ex)

--- a/src/Masa.Stack.Components/wwwroot/js/components.js
+++ b/src/Masa.Stack.Components/wwwroot/js/components.js
@@ -1,5 +1,14 @@
 window.MasaStackComponents = {}
 
+window.MasaStackComponents.clearOidcTokenCache = () => {
+    for (let i = sessionStorage.length - 1; i >= 0; i--) {
+        const key = sessionStorage.key(i);
+        if (key && key.startsWith('oidc.user:')) {
+            sessionStorage.removeItem(key);
+        }
+    }
+}
+
 window.MasaStackComponents.scrollTo = (target, inside = 'window') => {
     const targetElement = document.querySelector(target)
     if (!targetElement) return;


### PR DESCRIPTION
- 移除 AuthenticationStateProvider 和 IAccessTokenProvider 依赖
- 使用 IJSRuntime 直接调用 JavaScript 清除 OIDC Token 缓存
- 修改 WasmTeamStateManager 构造函数参数列表
- 切换团队时通过清除浏览器缓存并刷新页面实现静默重新登录
- 删除原有的强制刷新 token 逻辑和相关延迟等待
- 简化团队切换流程，提高响应速度和可靠性